### PR TITLE
Fixes: #13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:stretch
+FROM python:3.10-slim-buster
 
 WORKDIR /usr/src/app
 

--- a/chainsmith/config_file.py
+++ b/chainsmith/config_file.py
@@ -36,7 +36,7 @@ class ConfigFile(list):
                 if len(line) == 0:
                     chapter.append(ConfigLine(line))
                 elif line[0] == '[' and line[-1] == ']':
-                    chapter = ConfigChapter(line[1:-2].strip())
+                    chapter = ConfigChapter(line[1:-1].strip())
                     self.append(chapter)
                 else:
                     chapter.append(ConfigLine(line))


### PR DESCRIPTION
Seems like when we read the chapter name we leave out a trailing character.
Usually this is a space character, but on buster and bullseye it isn't...
